### PR TITLE
[Fix] Original Affirm implementation didn't need to check for billing…

### DIFF
--- a/erpnext_affirm/erpnext_affirm_integration/doctype/affirm_settings/affirm_settings.py
+++ b/erpnext_affirm/erpnext_affirm_integration/doctype/affirm_settings/affirm_settings.py
@@ -59,6 +59,7 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_ent
 
 class AffirmSettings(Document):
 	service_name = "Affirm"
+	is_embedable = True
 
 	def validate(self):
 		create_payment_gateway("Affirm")
@@ -73,6 +74,14 @@ class AffirmSettings(Document):
 
 		# never available to backend
 		return not is_backend
+
+	def get_embed_form(self, context=None):
+		return {
+			"form": "<div class=\"checkout-affirm-redirect-message\">You will be redirected to Affirm on checkout.</div>",
+			"style_url": "/assets/css/affirm_gateway_embed.css",
+			"script_url": "/assets/js/affirm_gateway_embed.js"
+		}
+
 
 @frappe.whitelist(allow_guest=1)
 def affirm_callback(checkout_token, reference_doctype, reference_docname):

--- a/erpnext_affirm/public/build.json
+++ b/erpnext_affirm/public/build.json
@@ -1,0 +1,9 @@
+{
+    "js/affirm_gateway_embed.js": [
+        "public/js/gateway/affirm_gateway_summary.html",
+        "public/js/gateway/embed.js"
+    ],
+    "css/affirm_gateway_embed.css": [
+        "public/css/affirm_gateway_embed.css"
+    ]
+}

--- a/erpnext_affirm/public/css/affirm_gateway_embed.css
+++ b/erpnext_affirm/public/css/affirm_gateway_embed.css
@@ -1,0 +1,7 @@
+.checkout-affirm-redirect-message {
+    font-weight: bold;
+    padding: 1em;
+    margin: 1em;
+    background: #fafbfc;
+    border-radius: .5em;
+}

--- a/erpnext_affirm/public/js/gateway/affirm_gateway_summary.html
+++ b/erpnext_affirm/public/js/gateway/affirm_gateway_summary.html
@@ -1,0 +1,18 @@
+{% if ( billing_info && billing_info.country ) { %}
+<div class="row">
+    <address class="col-sm-12">
+        {% if ( billing_info.address_1 ) { %} {% if ( billing_info.title ) { %} {%= billing_info.title %} 
+        <br> {% } %} {%= billing_info.address_1 %}
+        <br> {% if ( billing_info.address_2 ) { %} {%= billing_info.address_2 %}
+        <br> {% } %} {%= billing_info.city %}, {%= billing_info.state %} {%= billing_info.postal_code %}
+        <br> {%= billing_info.country %} {% } else { %} Address is incomplete. {% } %}
+    </address>
+    <div>You will be redirected to Affirm to complete checkout.</div>
+</div>
+{% } else { %}
+<div class="row">
+    <div class="col-sm-12">
+        <p class="error">Missing Billing Address</p>
+    </div>
+</div>
+{% } %}

--- a/erpnext_affirm/public/js/gateway/embed.js
+++ b/erpnext_affirm/public/js/gateway/embed.js
@@ -1,6 +1,5 @@
 /* global cart:false frappe:false */
-
-frappe.provide("frappe.gateway_selector")
+frappe.provide("frappe.gateway_selector");
 
 frappe.gateway_selector.affirm_embed = frappe.gateway_selector._generic_embed.extend({
     init: function (addressForm, formData) {
@@ -66,7 +65,9 @@ frappe.gateway_selector.affirm_embed = frappe.gateway_selector._generic_embed.ex
 
             // copy address for awc
             for (var key in this.process_data.billing_info) {
-                address[key] = this.process_data.billing_info[key]
+                if ({}.hasOwnProperty.call(this.process_data.billing_info, key)) {
+                    address[key] = this.process_data.billing_info[key];
+                }
             }
         } else {
             valid = false;

--- a/erpnext_affirm/public/js/gateway/embed.js
+++ b/erpnext_affirm/public/js/gateway/embed.js
@@ -1,0 +1,81 @@
+/* global cart:false frappe:false */
+
+frappe.provide("frappe.gateway_selector")
+
+frappe.gateway_selector.affirm_embed = frappe.gateway_selector._generic_embed.extend({
+    init: function (addressForm, formData) {
+        this.gateway = {
+            label: "Affirm",
+            name: "affirm",
+            muteProcessingCallback: true
+        };
+        this.addressForm = addressForm;
+        this.formData = formData;
+    },
+
+    collect_billing_info: function () {
+        var billing_info = {};
+        // collect billing field values
+
+        var result = this.addressForm.validate();
+        billing_info = $.extend({}, result.address);
+
+        return billing_info;
+    },
+
+    collect: function () {
+        this.process_data = {
+            billing_info: this.collect_billing_info()
+        };
+    },
+
+    getSummary: function () {
+        this.collect();
+
+        return frappe.render(
+            frappe.templates.affirm_gateway_summary, 
+            Object.assign({}, this.process_data));
+    },
+
+    validate: function () {
+        this.collect();
+        var valid = true;
+        var error = {};
+        var address = {};
+
+        if (this.process_data.billing_info) {
+            if (!this.process_data.billing_info.address_1) {
+                valid = false;
+                error['bill_line1'] = "Address line 1 is required";
+            }
+
+            if (!this.process_data.billing_info.city) {
+                valid = false;
+                error['bill_city'] = "City is required";
+            }
+
+            if (!this.process_data.billing_info.pincode) {
+                valid = false;
+                error['bill_pincode'] = "Postal Code is required";
+            }
+
+            if (!this.process_data.billing_info.country) {
+                valid = false;
+                error['bill_country'] = "Postal Code is required";
+            }
+
+            // copy address for awc
+            for (var key in this.process_data.billing_info) {
+                address[key] = this.process_data.billing_info[key]
+            }
+        } else {
+            valid = false;
+        }
+
+        return {
+            valid: valid,
+            errors: error,
+            address: address
+        };
+    }
+});


### PR DESCRIPTION
… causing issues on changes that came later

- Adds billing completion check
- Adds awc embed form api to handle billing address check
- Adds affirm "You will be redirected to affirm" message when selecting the affirm gateway

I am not merging this myself, as we should probably have a few more eyes testing this on staging. Also, this doesn't fix the permission issue last reported as I was unable to reproduce

![affirm-billing-fix](https://user-images.githubusercontent.com/1656249/41743421-b8507c66-756e-11e8-9b1e-2224c7999af4.gif)

^ sorry about the shitty gif quality

### **This pr requires changes on the gateway selector: https://github.com/DigiThinkIT/gateway_selector/pull/40**