### PR TITLE
fix: Affirm item discount information

### DIFF
--- a/erpnext_affirm/erpnext_affirm_integration/doctype/affirm_settings/affirm_settings.py
+++ b/erpnext_affirm/erpnext_affirm_integration/doctype/affirm_settings/affirm_settings.py
@@ -207,11 +207,21 @@ def build_checkout_data(**kwargs):
 		if 'shipping ' in tax.description.lower():
 			shipping_fee = tax.tax_amount
 
-	for item in order_doc.items:
+	for idx, item in enumerate(order_doc.items):
+		item_discount = item.price_list_rate - item.rate
+
+		if item_discount > 0:
+			discount_percent = 100 - (item.rate * 100 / item.price_list_rate)
+			discount_code = "LINE {} | {} | {}% DISCOUNT ($ -{:,.2f})".format(idx, item.item_code, discount_percent, item_discount)
+			discounts[discount_code] = {
+				"discount_amount": convert_to_cents(item_discount),
+				"discount_display_name": discount_code
+			}
+
 		items.append({
 			"display_name": item.item_name,
 			"sku": item.item_code,
-			"unit_price": convert_to_cents(item.rate),
+			"unit_price": convert_to_cents(item.price_list_rate),
 			"qty": item.qty,
 			"item_image_url": get_url(item.get("image", "")),
 			"item_url": get_url()
@@ -219,9 +229,9 @@ def build_checkout_data(**kwargs):
 
 	if order_doc.coupon_code:
 		discounts[order_doc.coupon_code] = {
-				"discount_amount": order_doc.discount_amount,
-				"discount_display_name": order_doc.coupon_code
-			}
+			"discount_amount": convert_to_cents(order_doc.discount_amount),
+			"discount_display_name": "Coupon Code {}".format(order_doc.coupon_code)
+		}
 
 	checkout_data = {
 		"merchant": {


### PR DESCRIPTION
The issue:

![jha-affirm-discount-wrong 0](https://user-images.githubusercontent.com/1656249/55765738-22839900-5a3f-11e9-8ca5-084b3c8d883a.png)

Although, we are passing the correct items and rates, if you pass the same SKU twice(or more times) to affirm they will replace the second instance of that SKU's rate with the first one causing affirm to report the wrong value for comped items or zero value rate items if there are more than one...

The trick here is to pass those discounts separately as discounts:

![jha-affirm-discount-fixed 0](https://user-images.githubusercontent.com/1656249/55765815-78584100-5a3f-11e9-82f5-346f4aecdc18.png)

However... affirm doesn't explicitly report those discounts as discounts neither does it show the totals as negative values. So for now I've labeled those as "Line {item no} | {sku} | % discount ($ -{discount})" so they can be easily spotted.