### PR TITLE
fix: authorize delivery if Affirm payment is successful

### DIFF
--- a/erpnext_affirm/erpnext_affirm_integration/doctype/affirm_settings/affirm_settings.py
+++ b/erpnext_affirm/erpnext_affirm_integration/doctype/affirm_settings/affirm_settings.py
@@ -87,7 +87,7 @@ class AffirmSettings(Document):
 @frappe.whitelist(allow_guest=1)
 def affirm_callback(checkout_token, reference_doctype, reference_docname):
 
-	frappe.log("""[AFFIRM] Affirm callback request: 
+	frappe.log("""[AFFIRM] Affirm callback request:
 		checkout_token: {0}
 		reference_doctype: {1}
 		reference_docname: {2}
@@ -303,6 +303,8 @@ def capture_payment(affirm_id, sales_order):
 		payment_entry.reference_no = affirm_data.get("transaction_id")
 		payment_entry.reference_date = getdate(affirm_data.get("created"))
 		payment_entry.submit()
+
+		frappe.db.set_value("Sales Order", sales_order, "authorize_delivery", True)
 	else:
 		frappe.throw("Something went wrong.")
 


### PR DESCRIPTION
Hook defined in https://github.com/DigiThinkIT/jhaudio_customizations/pull/1227.

<hr>

From Shelley:

> When Affirm orders are placed, they should not auto-authorize for production or delivery. I manually authorize them for production and when they are added to production schedule, **I capture payment, then they should auto-authorize for delivery.**